### PR TITLE
Add dynamic charts and improved UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# Torneo de Amigos
+
+Este proyecto es una web para registrar partidos, jugadores y estadísticas. A continuación se describe cómo integrar la votación de la figura del partido vía WhatsApp utilizando Twilio y cómo procesar esos votos con un flujo en n8n.
+
+## Requisitos
+- Node.js 18+
+- Cuenta de Twilio con acceso a la API de WhatsApp
+- Instancia de n8n
+- Una hoja de cálculo de Google con las pestañas `Jugadores`, `Partidos` y `Votos`.
+
+## Configuración del servidor
+1. Instala las dependencias:
+   ```bash
+   npm install express twilio node-fetch
+   ```
+2. Copia `server.js` y configura las variables de entorno:
+   - `N8N_WEBHOOK_URL`: URL del webhook de n8n que registrará los votos.
+   - `PORT`: puerto donde se ejecutará el servidor (opcional, por defecto 3000).
+3. Ejecuta el servidor:
+   ```bash
+   node server.js
+   ```
+4. En la consola de Twilio, configura la URL pública de `/webhook` como webhook de mensajes entrantes de WhatsApp.
+
+## Configuración de Google Sheets
+1. Crea una hoja con las pestañas **Jugadores**, **Partidos** y una pestaña opcional **Formacion** donde se publicarán los equipos recibidos por WhatsApp.
+2. Obtén el identificador de la hoja (`SHEET_ID`) y una clave de API válida (`API_KEY`).
+3. En `script.js` reemplaza los valores de `SHEET_ID` y `API_KEY` por los de tu proyecto.
+
+## Paso a paso en n8n
+1. **Webhook**: crea un nuevo nodo *Webhook* con método `POST`. Obtén la URL y utilízala como `N8N_WEBHOOK_URL` en el servidor.
+2. **Set**: agrega un nodo *Set* para transformar los campos recibidos (`from`, `message`).
+3. **Google Sheets**: usa el nodo *Google Sheets* con la operación *Append* para escribir una fila en la pestaña `Votos` con número de teléfono, mensaje y fecha.
+4. **Opcional**: añade nodos adicionales para validar el nombre del jugador o calcular el cierre de la votación.
+5. Activa el flujo y prueba enviando un mensaje de WhatsApp al número de Twilio.
+
+La web (`index.html` y `script.js`) obtendrá la información desde Google Sheets para mostrar estadísticas actualizadas. Ahora se incluyen gráficos dinámicos generados con Chart.js para visualizar goles por mes y rendimiento de los jugadores.
+
+## Prueba de funcionamiento (QA)
+
+Sigue estos pasos para verificar que todas las conexiones estén operativas:
+
+1. **Iniciar el servidor**
+   ```bash
+   export N8N_WEBHOOK_URL=<URL_DEL_WEBHOOK>
+   node server.js
+   ```
+2. **Arrancar n8n** y comprobar que el flujo con los nodos *Webhook* → *Set* → *Google Sheets* esté activo.
+3. **Configurar Twilio** para enviar los mensajes entrantes al endpoint público `/webhook` del servidor.
+4. **Abrir `index.html`** en el navegador y revisar que los jugadores y partidos se cargan desde Sheets sin errores.
+5. **Enviar un WhatsApp** al número de Twilio con el nombre de un jugador válido. Debería recibirse la respuesta "Voto recibido para: ...".
+6. **Revisar n8n** y la hoja de cálculo para confirmar que se registró una fila en la pestaña `Votos` con el teléfono, el mensaje y la fecha.
+7. **Actualizar la página** y verificar que las estadísticas reflejan el nuevo voto si la hoja lo procesa.
+
+Si cualquiera de estos pasos falla, revisa los logs de n8n, del servidor Node y de Twilio para identificar el problema.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "torneo-amigos-server",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "node-fetch": "^2.6.11",
+    "twilio": "^4.5.1"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -4,9 +4,25 @@ let mapaJugadores = {};
 let contadorID = 1;
 let nuevosJugadores = [];
 
+let graficoGoles = null;
+let graficoRendimiento = null;
+
+const SHEET_ID = "<SHEET_ID>";
+const API_KEY = "<API_KEY>";
+
 function mostrarTab(id) {
-  document.querySelectorAll(".tab").forEach(tab => tab.style.display = "none");
-  document.getElementById(id).style.display = "block";
+  document.querySelectorAll(".tab").forEach(tab => {
+    tab.style.display = "none";
+    tab.style.opacity = 0;
+    tab.style.transform = "translateY(20px)";
+  });
+  const tab = document.getElementById(id);
+  tab.style.display = "block";
+  setTimeout(() => {
+    tab.style.opacity = 1;
+    tab.style.transform = "translateY(0)";
+  }, 0);
+  if (id === "formulario") cargarFormacionPrevia();
 }
 
 function abrirModalFormulario() {
@@ -57,7 +73,7 @@ document.getElementById("formJugador").addEventListener("submit", e => {
 });
 
 // Agregar fila con botón para eliminar y máximo de 5
-function agregarFila(equipo) {
+function agregarFila(equipo, nombrePreseleccionado = "") {
   const tbody = document.getElementById("tabla" + equipo);
   if (tbody.querySelectorAll("tr").length >= 5) {
     alert("Máximo 5 jugadores por equipo.");
@@ -73,6 +89,16 @@ function agregarFila(equipo) {
     opt.textContent = j.jugador_nombre;
     select.appendChild(opt);
   });
+  if (nombrePreseleccionado) {
+    const existe = jugadoresLista.some(j => j.jugador_nombre === nombrePreseleccionado);
+    if (!existe) {
+      const opt = document.createElement("option");
+      opt.value = nombrePreseleccionado;
+      opt.textContent = nombrePreseleccionado;
+      select.appendChild(opt);
+    }
+    select.value = nombrePreseleccionado;
+  }
 
   const golesInput = document.createElement("input");
   golesInput.type = "number";
@@ -164,34 +190,171 @@ function descargarJugadoresCSV() {
   a.click();
   URL.revokeObjectURL(a.href);
 }
-// Cargar jugadores desde GitHub
-async function cargarJugadoresDesdeGitHub() {
-  const url = 'jugadores.csv';
+function procesarDatos() {
+  const posiciones = {};
+  const historial = [];
+  const actividad = {};
+  const golesMes = {};
+  const partidosSet = new Set();
+  const partidosPorFecha = {};
+
+  datosPartidos.forEach(d => {
+    if (!d || !d.fecha_partido || !d.nombre_partido) return;
+    const clave = `${d.fecha_partido}-${d.nombre_partido}`;
+    if (!partidosPorFecha[clave]) partidosPorFecha[clave] = [];
+    partidosPorFecha[clave].push(d);
+    partidosSet.add(`${d.nombre_torneo}||${d.fecha_partido}`);
+    const mes = d.fecha_partido.slice(0,7);
+    golesMes[mes] = (golesMes[mes] || 0) + d.goles_partido;
+  });
+
+  const clavesOrdenadas = Object.keys(partidosPorFecha).sort().reverse();
+  const ultimosHTML = clavesOrdenadas.slice(0, 5).map(clave => {
+    const jugadores = partidosPorFecha[clave];
+    const torneo = jugadores[0]?.nombre_torneo || "Torneo";
+    const equipos = { Blanco: [], Negro: [] };
+    let golesBlanco = 0, golesNegro = 0;
+
+    jugadores.forEach(j => {
+      equipos[j.equipo].push(`${j.jugador_nombre} (${j.goles_partido})`);
+      if (j.equipo === 'Blanco') golesBlanco += j.goles_partido;
+      else golesNegro += j.goles_partido;
+    });
+
+    const goleador = jugadores.reduce((a, b) => (a.goles_partido > b.goles_partido ? a : b));
+    return `
+      <div class="card fade-in-up">
+        <strong>${torneo} - ${clave}</strong><br/>
+        Blanco ${golesBlanco} vs ${golesNegro} Negro<br/>
+        🥇 Goleador: ${goleador.jugador_nombre} (${goleador.goles_partido})<br/>
+      </div>
+    `;
+  });
+
+  document.getElementById("ultimosPartidos").innerHTML = ultimosHTML.join("");
+
+  Object.values(partidosPorFecha).forEach(jugadores => {
+    const golesPorEquipo = {};
+    jugadores.forEach(j => {
+      golesPorEquipo[j.equipo] = (golesPorEquipo[j.equipo] || 0) + j.goles_partido;
+    });
+
+    const equipos = Object.keys(golesPorEquipo);
+    let resultado;
+    if (golesPorEquipo[equipos[0]] > golesPorEquipo[equipos[1]]) resultado = equipos[0];
+    else if (golesPorEquipo[equipos[0]] < golesPorEquipo[equipos[1]]) resultado = equipos[1];
+    else resultado = "empate";
+
+    const maxGoles = Math.max(...jugadores.map(j => j.goles_partido));
+    const goleadores = jugadores.filter(j => j.goles_partido === maxGoles && maxGoles > 0);
+
+    jugadores.forEach(j => {
+      const id = j.id_jugador;
+      if (!posiciones[id]) posiciones[id] = { nombre: j.jugador_nombre, puntos: 0, goles: 0, partidos: 0 };
+      if (!actividad[id]) actividad[id] = { nombre: j.jugador_nombre, presencia: 0 };
+
+      posiciones[id].goles += j.goles_partido;
+      posiciones[id].partidos += 1;
+      actividad[id].presencia += j.flageado;
+
+      if (resultado !== "empate" && j.equipo === resultado) posiciones[id].puntos += 3;
+      else if (resultado === "empate") posiciones[id].puntos += 1;
+
+      if (goleadores.some(g => g.id_jugador === j.id_jugador)) posiciones[id].puntos += 1;
+
+      historial.push(j);
+    });
+  });
+
+  actualizarTabla("tablaPosiciones", posiciones, ["nombre", "puntos", "goles", "partidos"]);
+  actualizarTabla("tablaGoleadores", posiciones, ["nombre", "goles"]);
+  actualizarTablaTitulares(actividad, partidosSet.size);
+  actualizarHistorial(historial);
+  renderGraficos(golesMes, posiciones);
+}
+
+function actualizarTabla(id, datos, campos) {
+  const tbody = document.getElementById(id);
+  tbody.innerHTML = "";
+  Object.values(datos)
+    .sort((a, b) => (b.puntos ?? b.presencia ?? 0) - (a.puntos ?? a.presencia ?? 0))
+    .forEach(d => {
+      const fila = campos.map(c => `<td>${d[c]}</td>`).join("");
+      tbody.innerHTML += `<tr>${fila}</tr>`;
+    });
+}
+
+function actualizarTablaTitulares(actividad, totalFechas) {
+  const tbody = document.getElementById("tablaTitulares");
+  tbody.innerHTML = "";
+  Object.values(actividad)
+    .sort((a, b) => b.presencia - a.presencia)
+    .forEach(j => {
+      const porcentaje = Math.min((j.presencia / totalFechas) * 100, 100).toFixed(0);
+      tbody.innerHTML += `<tr><td>${j.nombre}</td><td>${j.presencia}</td><td>${porcentaje}%</td></tr>`;
+    });
+}
+
+function actualizarHistorial(filas) {
+  const tbody = document.getElementById("tablaHistorial");
+  tbody.innerHTML = "";
+  filas.forEach(d => {
+    tbody.innerHTML += `<tr><td>${d.fecha_partido}</td><td>${d.nombre_partido}</td><td>${d.jugador_nombre}</td><td>${d.equipo}</td><td>${d.goles_partido}</td></tr>`;
+  });
+}
+
+function renderGraficos(golesMes, posiciones) {
+  const ctx1 = document.getElementById('graficoGolesPorMes').getContext('2d');
+  const labels1 = Object.keys(golesMes).sort();
+  const data1 = labels1.map(m => golesMes[m]);
+  if (graficoGoles) graficoGoles.destroy();
+  graficoGoles = new Chart(ctx1, {
+    type: 'bar',
+    data: { labels: labels1, datasets: [{ label: 'Goles', data: data1, backgroundColor: '#008080' }] },
+    options: { responsive: true, plugins: { legend: { display: false } } }
+  });
+
+  const ctx2 = document.getElementById('graficoRendimientoJugadores').getContext('2d');
+  const top = Object.values(posiciones).sort((a,b) => b.puntos - a.puntos).slice(0,5);
+  const labels2 = top.map(t => t.nombre);
+  const data2 = top.map(t => t.puntos);
+  if (graficoRendimiento) graficoRendimiento.destroy();
+  graficoRendimiento = new Chart(ctx2, {
+    type: 'radar',
+    data: { labels: labels2, datasets: [{ label: 'Puntos', data: data2, backgroundColor: 'rgba(0,128,128,0.4)', borderColor: '#008080' }] },
+    options: { responsive: true, scales: { r: { beginAtZero: true } } }
+  });
+}
+
+
+
+// Ejecutar al cargar la web
+
+
+// Cargar datos desde Google Sheets
+async function cargarJugadoresDesdeSheets() {
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/Jugadores?key=${API_KEY}`;
   try {
     const res = await fetch(url);
-    const text = await res.text();
-    const rows = text.trim().split("\n").slice(1);
-    jugadoresLista = rows.map(row => {
-      const [id, nombre, fecha] = row.split(",");
-      mapaJugadores[nombre] = parseInt(id);
-      if (parseInt(id) >= contadorID) contadorID = parseInt(id) + 1;
-      return { id: parseInt(id), jugador_nombre: nombre, fecha_alta: fecha };
+    const { values } = await res.json();
+    jugadoresLista = (values || []).slice(1).map(([id, nombre, fecha]) => {
+      const idNum = parseInt(id);
+      mapaJugadores[nombre] = idNum;
+      if (idNum >= contadorID) contadorID = idNum + 1;
+      return { id: idNum, jugador_nombre: nombre, fecha_alta: fecha };
     });
   } catch (err) {
-    console.error("Error al cargar jugadores:", err);
+    console.error('Error al cargar jugadores (Sheets):', err);
   }
 }
 
-// Cargar resultados desde GitHub
-async function cargarCSVDesdeGitHub() {
-  const url = 'resultados.csv';
+async function cargarPartidosDesdeSheets() {
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/Partidos?key=${API_KEY}`;
   try {
     const res = await fetch(url);
-    const text = await res.text();
-    const rows = text.trim().split("\n").slice(1);
-    rows.forEach(row => {
-      if (!row.trim()) return;
-      const [nombre_torneo, fecha_inicio_torneo, fecha_partido, nombre_partido, jugador_nombre, id_jugador, equipo, goles_partido, flageado] = row.split(",");
+    const { values } = await res.json();
+    (values || []).slice(1).forEach(row => {
+      const [nombre_torneo, fecha_inicio_torneo, fecha_partido, nombre_partido, jugador_nombre, id_jugador, equipo, goles_partido, flageado] = row;
       datosPartidos.push({
         nombre_torneo,
         fecha_inicio_torneo,
@@ -206,234 +369,39 @@ async function cargarCSVDesdeGitHub() {
     });
     procesarDatos();
   } catch (err) {
-    console.error("Error al cargar resultados:", err);
+    console.error('Error al cargar partidos (Sheets):', err);
   }
 }
-function procesarDatos() {
-  const posiciones = {};
-  const historial = [];
-  const actividad = {};
-  const partidosSet = new Set();
-  const partidosPorFecha = {};
 
-  datosPartidos.forEach(d => {
-    if (!d || !d.fecha_partido || !d.nombre_partido) return;
-    const clave = `${d.fecha_partido}-${d.nombre_partido}`;
-    if (!partidosPorFecha[clave]) partidosPorFecha[clave] = [];
-    partidosPorFecha[clave].push(d);
-    partidosSet.add(`${d.nombre_torneo}||${d.fecha_partido}`);
-  });
-
-  const clavesOrdenadas = Object.keys(partidosPorFecha).sort().reverse();
-  const ultimosHTML = clavesOrdenadas.slice(0, 5).map(clave => {
-    const jugadores = partidosPorFecha[clave];
-    const torneo = jugadores[0]?.nombre_torneo || "Torneo";
-    const equipos = { Blanco: [], Negro: [] };
-    let golesBlanco = 0, golesNegro = 0;
-
-    jugadores.forEach(j => {
-      equipos[j.equipo].push(`${j.jugador_nombre} (${j.goles_partido})`);
-      if (j.equipo === 'Blanco') golesBlanco += j.goles_partido;
-      else golesNegro += j.goles_partido;
+async function cargarFormacionDesdeSheets() {
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/Formacion?key=${API_KEY}`;
+  try {
+    const res = await fetch(url);
+    const { values } = await res.json();
+    const blanco = [], negro = [];
+    (values || []).slice(1).forEach(row => {
+      if (row[0]) blanco.push(row[0]);
+      if (row[1]) negro.push(row[1]);
     });
-
-    const goleador = jugadores.reduce((a, b) => (a.goles_partido > b.goles_partido ? a : b));
-    return `
-      <div>
-        <strong>${torneo} - ${clave}</strong><br/>
-        Blanco ${golesBlanco} vs ${golesNegro} Negro<br/>
-        🥇 Goleador: ${goleador.jugador_nombre} (${goleador.goles_partido})<br/>
-      </div>
-    `;
-  });
-
-  document.getElementById("ultimosPartidos").innerHTML = ultimosHTML.join("");
-
-  Object.values(partidosPorFecha).forEach(jugadores => {
-    const golesPorEquipo = {};
-    jugadores.forEach(j => {
-      golesPorEquipo[j.equipo] = (golesPorEquipo[j.equipo] || 0) + j.goles_partido;
-    });
-
-    const equipos = Object.keys(golesPorEquipo);
-    let resultado;
-    if (golesPorEquipo[equipos[0]] > golesPorEquipo[equipos[1]]) resultado = equipos[0];
-    else if (golesPorEquipo[equipos[0]] < golesPorEquipo[equipos[1]]) resultado = equipos[1];
-    else resultado = "empate";
-
-    const maxGoles = Math.max(...jugadores.map(j => j.goles_partido));
-    const goleadores = jugadores.filter(j => j.goles_partido === maxGoles && maxGoles > 0);
-
-    jugadores.forEach(j => {
-      const id = j.id_jugador;
-      if (!posiciones[id]) posiciones[id] = { nombre: j.jugador_nombre, puntos: 0, goles: 0, partidos: 0 };
-      if (!actividad[id]) actividad[id] = { nombre: j.jugador_nombre, presencia: 0 };
-
-      posiciones[id].goles += j.goles_partido;
-      posiciones[id].partidos += 1;
-      actividad[id].presencia += j.flageado;
-
-      if (resultado !== "empate" && j.equipo === resultado) posiciones[id].puntos += 3;
-      else if (resultado === "empate") posiciones[id].puntos += 1;
-
-      if (goleadores.some(g => g.id_jugador === j.id_jugador)) posiciones[id].puntos += 1;
-
-      historial.push(j);
-    });
-  });
-
-  actualizarTabla("tablaPosiciones", posiciones, ["nombre", "puntos", "goles", "partidos"]);
-  actualizarTabla("tablaGoleadores", posiciones, ["nombre", "goles"]);
-  actualizarTablaTitulares(actividad, partidosSet.size);
-  actualizarHistorial(historial);
+    return { Blanco: blanco, Negro: negro };
+  } catch (err) {
+    console.error('Error al cargar formación (Sheets):', err);
+    return { Blanco: [], Negro: [] };
+  }
 }
 
-function actualizarTabla(id, datos, campos) {
-  const tbody = document.getElementById(id);
-  tbody.innerHTML = "";
-  Object.values(datos)
-    .sort((a, b) => (b.puntos ?? b.presencia ?? 0) - (a.puntos ?? a.presencia ?? 0))
-    .forEach(d => {
-      const fila = campos.map(c => `<td>${d[c]}</td>`).join("");
-      tbody.innerHTML += `<tr>${fila}</tr>`;
-    });
+async function cargarFormacionPrevia() {
+  const formacion = await cargarFormacionDesdeSheets();
+  document.getElementById("tablaBlanco").innerHTML = "";
+  document.getElementById("tablaNegro").innerHTML = "";
+  formacion.Blanco.forEach(n => agregarFila("Blanco", n));
+  formacion.Negro.forEach(n => agregarFila("Negro", n));
 }
 
-function actualizarTablaTitulares(actividad, totalFechas) {
-  const tbody = document.getElementById("tablaTitulares");
-  tbody.innerHTML = "";
-  Object.values(actividad)
-    .sort((a, b) => b.presencia - a.presencia)
-    .forEach(j => {
-      const porcentaje = Math.min((j.presencia / totalFechas) * 100, 100).toFixed(0);
-      tbody.innerHTML += `<tr><td>${j.nombre}</td><td>${j.presencia}</td><td>${porcentaje}%</td></tr>`;
-    });
-}
-
-function actualizarHistorial(filas) {
-  const tbody = document.getElementById("tablaHistorial");
-  tbody.innerHTML = "";
-  filas.forEach(d => {
-    tbody.innerHTML += `<tr><td>${d.fecha_partido}</td><td>${d.nombre_partido}</td><td>${d.jugador_nombre}</td><td>${d.equipo}</td><td>${d.goles_partido}</td></tr>`;
-  });
-}
-
-// Ejecutar al cargar la web
+// Ejecutar al cargar la web desde Sheets
 (async () => {
-  await cargarJugadoresDesdeGitHub();
-  await cargarCSVDesdeGitHub();
+  await cargarJugadoresDesdeSheets();
+  await cargarPartidosDesdeSheets();
 })();
-function procesarDatos() {
-  const posiciones = {};
-  const historial = [];
-  const actividad = {};
-  const partidosSet = new Set();
-  const partidosPorFecha = {};
 
-  datosPartidos.forEach(d => {
-    if (!d || !d.fecha_partido || !d.nombre_partido) return;
-    const clave = `${d.fecha_partido}-${d.nombre_partido}`;
-    if (!partidosPorFecha[clave]) partidosPorFecha[clave] = [];
-    partidosPorFecha[clave].push(d);
-    partidosSet.add(`${d.nombre_torneo}||${d.fecha_partido}`);
-  });
 
-  const clavesOrdenadas = Object.keys(partidosPorFecha).sort().reverse();
-  const ultimosHTML = clavesOrdenadas.slice(0, 5).map(clave => {
-    const jugadores = partidosPorFecha[clave];
-    const torneo = jugadores[0]?.nombre_torneo || "Torneo";
-    const equipos = { Blanco: [], Negro: [] };
-    let golesBlanco = 0, golesNegro = 0;
-
-    jugadores.forEach(j => {
-      equipos[j.equipo].push(`${j.jugador_nombre} (${j.goles_partido})`);
-      if (j.equipo === 'Blanco') golesBlanco += j.goles_partido;
-      else golesNegro += j.goles_partido;
-    });
-
-    const goleador = jugadores.reduce((a, b) => (a.goles_partido > b.goles_partido ? a : b));
-    return `
-      <div>
-        <strong>${torneo} - ${clave}</strong><br/>
-        Blanco ${golesBlanco} vs ${golesNegro} Negro<br/>
-        🥇 Goleador: ${goleador.jugador_nombre} (${goleador.goles_partido})<br/>
-      </div>
-    `;
-  });
-
-  document.getElementById("ultimosPartidos").innerHTML = ultimosHTML.join("");
-
-  Object.values(partidosPorFecha).forEach(jugadores => {
-    const golesPorEquipo = {};
-    jugadores.forEach(j => {
-      golesPorEquipo[j.equipo] = (golesPorEquipo[j.equipo] || 0) + j.goles_partido;
-    });
-
-    const equipos = Object.keys(golesPorEquipo);
-    let resultado;
-    if (golesPorEquipo[equipos[0]] > golesPorEquipo[equipos[1]]) resultado = equipos[0];
-    else if (golesPorEquipo[equipos[0]] < golesPorEquipo[equipos[1]]) resultado = equipos[1];
-    else resultado = "empate";
-
-    const maxGoles = Math.max(...jugadores.map(j => j.goles_partido));
-    const goleadores = jugadores.filter(j => j.goles_partido === maxGoles && maxGoles > 0);
-
-    jugadores.forEach(j => {
-      const id = j.id_jugador;
-      if (!posiciones[id]) posiciones[id] = { nombre: j.jugador_nombre, puntos: 0, goles: 0, partidos: 0 };
-      if (!actividad[id]) actividad[id] = { nombre: j.jugador_nombre, presencia: 0 };
-
-      posiciones[id].goles += j.goles_partido;
-      posiciones[id].partidos += 1;
-      actividad[id].presencia += j.flageado;
-
-      if (resultado !== "empate" && j.equipo === resultado) posiciones[id].puntos += 3;
-      else if (resultado === "empate") posiciones[id].puntos += 1;
-
-      if (goleadores.some(g => g.id_jugador === j.id_jugador)) posiciones[id].puntos += 1;
-
-      historial.push(j);
-    });
-  });
-
-  actualizarTabla("tablaPosiciones", posiciones, ["nombre", "puntos", "goles", "partidos"]);
-  actualizarTabla("tablaGoleadores", posiciones, ["nombre", "goles"]);
-  actualizarTablaTitulares(actividad, partidosSet.size);
-  actualizarHistorial(historial);
-}
-
-function actualizarTabla(id, datos, campos) {
-  const tbody = document.getElementById(id);
-  tbody.innerHTML = "";
-  Object.values(datos)
-    .sort((a, b) => (b.puntos ?? b.presencia ?? 0) - (a.puntos ?? a.presencia ?? 0))
-    .forEach(d => {
-      const fila = campos.map(c => `<td>${d[c]}</td>`).join("");
-      tbody.innerHTML += `<tr>${fila}</tr>`;
-    });
-}
-
-function actualizarTablaTitulares(actividad, totalFechas) {
-  const tbody = document.getElementById("tablaTitulares");
-  tbody.innerHTML = "";
-  Object.values(actividad)
-    .sort((a, b) => b.presencia - a.presencia)
-    .forEach(j => {
-      const porcentaje = Math.min((j.presencia / totalFechas) * 100, 100).toFixed(0);
-      tbody.innerHTML += `<tr><td>${j.nombre}</td><td>${j.presencia}</td><td>${porcentaje}%</td></tr>`;
-    });
-}
-
-function actualizarHistorial(filas) {
-  const tbody = document.getElementById("tablaHistorial");
-  tbody.innerHTML = "";
-  filas.forEach(d => {
-    tbody.innerHTML += `<tr><td>${d.fecha_partido}</td><td>${d.nombre_partido}</td><td>${d.jugador_nombre}</td><td>${d.equipo}</td><td>${d.goles_partido}</td></tr>`;
-  });
-}
-
-// Ejecutar al cargar la web
-(async () => {
-  await cargarJugadoresDesdeGitHub();
-  await cargarCSVDesdeGitHub();
-})();

--- a/server.js
+++ b/server.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const fetch = require('node-fetch');
+const { MessagingResponse } = require('twilio').twiml;
+
+const app = express();
+app.use(express.urlencoded({ extended: false }));
+
+app.post('/webhook', async (req, res) => {
+  const from = req.body.From;
+  const message = (req.body.Body || '').trim();
+  const twiml = new MessagingResponse();
+
+  try {
+    if (process.env.N8N_WEBHOOK_URL) {
+      await fetch(process.env.N8N_WEBHOOK_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ from, message })
+      });
+    }
+    twiml.message(`Voto recibido para: ${message}`);
+  } catch (err) {
+    console.error('Error enviando a n8n', err);
+    twiml.message('No se pudo registrar tu voto.');
+  }
+
+  res.writeHead(200, { 'Content-Type': 'text/xml' });
+  res.end(twiml.toString());
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Servidor escuchando en puerto ${PORT}`));

--- a/style.css
+++ b/style.css
@@ -83,6 +83,7 @@ body {
   padding: 40px;
   box-sizing: border-box;
   overflow-y: auto;
+  scroll-behavior: smooth;
 }
 
 main {
@@ -97,15 +98,11 @@ main {
   border-radius: 12px;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.05);
   margin-bottom: 30px;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.4s, transform 0.4s;
 }
 
-#ultimosPartidos div {
-  background: #fff;
-  margin-bottom: 20px;
-  padding: 15px;
-  border-radius: 8px;
-  box-shadow: 0 0 6px rgba(0, 0, 0, 0.05);
-}
 
 h2 {
   margin-top: 0;
@@ -223,4 +220,24 @@ textarea, input, select {
 .tabla-form th, .tabla-form td {
   border: 1px solid #ccc;
   padding: 8px;
+}
+
+.card {
+  background: #fff;
+  margin-bottom: 20px;
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  transform: translateY(10px);
+  opacity: 0;
+  animation: fadeInUp 0.6s forwards;
+}
+
+.fade-in-up {
+  animation: fadeInUp 0.6s forwards;
+}
+
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
 }


### PR DESCRIPTION
## Summary
- preload formations from Sheets when opening the form
- add animated tabs and card styles for a smoother UI
- render goals per month and top player charts with Chart.js
- document new Formacion sheet and charts in README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6840eb195f148321b7fab57bce535693