### PR TITLE
Load sheet config from server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env and set your keys
+SHEET_ID=your_google_sheet_id
+API_KEY=your_google_api_key

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Este proyecto es una web para registrar partidos, jugadores y estadísticas. A c
 ## Configuración del servidor
 1. Instala las dependencias:
    ```bash
-   npm install express twilio node-fetch
+   npm install express twilio node-fetch dotenv
    ```
-2. Copia `server.js` y configura las variables de entorno:
+2. Copia `.env.example` a `.env` y completa:
+   - `SHEET_ID`: identificador de tu hoja de cálculo.
+   - `API_KEY`: clave de API de Google.
    - `N8N_WEBHOOK_URL`: URL del webhook de n8n que registrará los votos.
    - `PORT`: puerto donde se ejecutará el servidor (opcional, por defecto 3000).
 3. Ejecuta el servidor:
@@ -25,7 +27,7 @@ Este proyecto es una web para registrar partidos, jugadores y estadísticas. A c
 ## Configuración de Google Sheets
 1. Crea una hoja con las pestañas **Jugadores** y **Partidos**.
 2. Obtén el identificador de la hoja (`SHEET_ID`) y una clave de API válida (`API_KEY`).
-3. En `script.js` reemplaza los valores de `SHEET_ID` y `API_KEY` por los de tu proyecto.
+3. Guarda ambos valores en el archivo `.env` creado en el paso anterior.
 
 ## Paso a paso en n8n
 1. **Webhook**: crea un nuevo nodo *Webhook* con método `POST`. Obtén la URL y utilízala como `N8N_WEBHOOK_URL` en el servidor.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "dotenv": "^16.0.0",
     "express": "^4.18.2",
     "node-fetch": "^2.6.11",
     "twilio": "^4.5.1"

--- a/script.js
+++ b/script.js
@@ -4,8 +4,19 @@ let mapaJugadores = {};
 let contadorID = 1;
 let nuevosJugadores = [];
 
-const SHEET_ID = "<SHEET_ID>";
-const API_KEY = "<API_KEY>";
+let SHEET_ID = '';
+let API_KEY = '';
+
+async function cargarConfig() {
+  try {
+    const res = await fetch('/env');
+    const cfg = await res.json();
+    SHEET_ID = cfg.SHEET_ID;
+    API_KEY = cfg.API_KEY;
+  } catch (err) {
+    console.error('Error cargando configuración:', err);
+  }
+}
 
 function mostrarTab(id) {
   document.querySelectorAll(".tab").forEach(tab => tab.style.display = "none");
@@ -431,6 +442,7 @@ async function cargarPartidosDesdeSheets() {
 
 // Ejecutar al cargar la web desde Sheets
 (async () => {
+  await cargarConfig();
   await cargarJugadoresDesdeSheets();
   await cargarPartidosDesdeSheets();
 })();

--- a/server.js
+++ b/server.js
@@ -1,9 +1,18 @@
 const express = require('express');
 const fetch = require('node-fetch');
 const { MessagingResponse } = require('twilio').twiml;
+require('dotenv').config();
 
 const app = express();
 app.use(express.urlencoded({ extended: false }));
+app.use(express.json());
+
+app.get('/env', (req, res) => {
+  res.json({
+    SHEET_ID: process.env.SHEET_ID || '',
+    API_KEY: process.env.API_KEY || ''
+  });
+});
 
 app.post('/webhook', async (req, res) => {
   const from = req.body.From;


### PR DESCRIPTION
## Summary
- add `.env.example` for storing `SHEET_ID` and `API_KEY`
- fetch environment values from `/env` endpoint in `script.js`
- expose `/env` endpoint in `server.js`
- document new `.env` setup in `README`
- include `dotenv` dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68410a91a030832195ff0a5c77f90644