### PR TITLE
Simplify install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Este proyecto es una web para registrar partidos, jugadores y estadísticas. A c
 ## Configuración del servidor
 1. Instala las dependencias:
    ```bash
-   npm install express twilio node-fetch
+   npm install
    ```
 2. Copia `server.js` y configura las variables de entorno:
    - `N8N_WEBHOOK_URL`: URL del webhook de n8n que registrará los votos.


### PR DESCRIPTION
## Summary
- replace package specific `npm install express twilio node-fetch` with simpler `npm install`

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68410b798b8083218d5f1972f6c61b5f