### PR TITLE
Implement interactive match registration and WhatsApp notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         <input type="date" id="fecha_partido" required/>
         <input type="text" id="nombre_partido" placeholder="Nombre del partido" required/>
 
-        <div class="equipos-grid">
+        <div class="equipos-grid" style="display:none;">
           <fieldset>
             <legend>⚪ Equipo Blanco</legend>
             <div id="equipoBlanco"></div>
@@ -37,6 +37,14 @@
         </div>
 
         <button type="submit">Guardar Partido</button>
+      </form>
+    </section>
+
+    <section id="seccionVoto" style="display:none;">
+      <h2>Votar Figura</h2>
+      <form id="formFigura">
+        <select id="selectFigura" required></select>
+        <button type="submit">Enviar Voto</button>
       </form>
     </section>
 

--- a/server.js
+++ b/server.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const fetch = require('node-fetch');
 const { MessagingResponse } = require('twilio').twiml;
+const twilio = require('twilio');
 const SHEET_ID = "15SFBZPl54ZaYNrTeog0COivI0e9wI_eHLcZJTaNUz7Y";
 const API_KEY = "AIzaSyBs6mHcPVaWd4wp3NA3bnwbQOYJ1Rr9p_c";
 
 const app = express();
 app.use(express.urlencoded({ extended: false }));
+app.use(express.json());
 
 app.post('/webhook', async (req, res) => {
   const from = req.body.From;
@@ -28,6 +30,24 @@ app.post('/webhook', async (req, res) => {
 
   res.writeHead(200, { 'Content-Type': 'text/xml' });
   res.end(twiml.toString());
+});
+
+app.post('/notify', async (req, res) => {
+  const { numeros = [], partido } = req.body;
+  const client = twilio(process.env.TWILIO_SID, process.env.TWILIO_TOKEN);
+  const from = `whatsapp:${process.env.TWILIO_WHATSAPP_NUMBER}`;
+  const body = `Respondé con el nombre de tu figura del partido: ${partido}`;
+  try {
+    await Promise.all(
+      numeros.map((n) =>
+        client.messages.create({ from, to: `whatsapp:${n}`, body })
+      )
+    );
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('Error enviando notificaciones', err);
+    res.status(500).json({ error: 'Fallo notificaciones' });
+  }
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- add dynamic player form triggered by match name
- store phone numbers from Google Sheets
- save matches and send notifications to n8n and Twilio
- add figure voting section and webhook integration

## Testing
- `npm install` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_6844fddec2f88321b52b99bee1d66af3