### PR TITLE
Improve UX with modals and mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
       </div>
     </div>
 
-    <div id="overlay" class="overlay" onclick="cerrarModalJugador()"></div>
+    <div id="overlay" class="overlay" onclick="cerrarModalJugador(); cerrarModalFormulario()"></div>
 
     <section>
       <h2>Últimos partidos</h2>

--- a/script.js
+++ b/script.js
@@ -19,16 +19,7 @@ async function cargarJugadores() {
   }
 }
 
-// 🧩 Modal de jugador
-function abrirModalJugador() {
-  document.getElementById("modalJugador").style.display = "flex";
-  document.getElementById("overlay").style.display = "block";
-}
-function cerrarModalJugador() {
-  document.getElementById("modalJugador").style.display = "none";
-  document.getElementById("overlay").style.display = "none";
-  document.getElementById("nuevoJugador").value = "";
-}
+
 
 // ➕ Agregar jugador al array
 document.getElementById("formJugador").addEventListener("submit", e => {
@@ -318,22 +309,36 @@ function mostrarTab(tabId) {
 
 // 🪟 Abrir y cerrar modal de formulario
 function abrirModalFormulario() {
-  document.getElementById("modalFormulario").style.display = "block";
+  const modal = document.getElementById("modalFormulario");
+  const overlay = document.getElementById("overlay");
+  overlay.style.display = "block";
+  modal.style.display = "flex";
+  requestAnimationFrame(() => modal.classList.add("show"));
 }
 
 function cerrarModalFormulario() {
-  document.getElementById("modalFormulario").style.display = "none";
+  const modal = document.getElementById("modalFormulario");
+  modal.classList.remove("show");
+  const overlay = document.getElementById("overlay");
+  overlay.style.display = "none";
+  setTimeout(() => (modal.style.display = "none"), 300);
   document.getElementById("formPartido").reset();
   document.querySelector(".equipos-grid").style.display = "none";
 }
 
 // 🪟 Abrir y cerrar modal de jugador nuevo
 function abrirModalJugador() {
-  document.getElementById("modalJugador").style.display = "block";
-  document.getElementById("overlay").style.display = "block";
+  const modal = document.getElementById("modalJugador");
+  const overlay = document.getElementById("overlay");
+  overlay.style.display = "block";
+  modal.style.display = "flex";
+  requestAnimationFrame(() => modal.classList.add("show"));
 }
 
 function cerrarModalJugador() {
-  document.getElementById("modalJugador").style.display = "none";
-  document.getElementById("overlay").style.display = "none";
+  const modal = document.getElementById("modalJugador");
+  modal.classList.remove("show");
+  const overlay = document.getElementById("overlay");
+  overlay.style.display = "none";
+  setTimeout(() => (modal.style.display = "none"), 300);
 }

--- a/style.css
+++ b/style.css
@@ -139,6 +139,17 @@ input[type="checkbox"] {
   justify-content: center;
   align-items: center;
   z-index: 10;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.modal.show {
+  display: flex;
+  opacity: 1;
+}
+
+.modal.show .modal-content {
+  transform: scale(1);
 }
 
 .modal-content {
@@ -150,6 +161,8 @@ input[type="checkbox"] {
   position: relative;
   color: white;
   backdrop-filter: blur(4px);
+  transform: scale(0.95);
+  transition: transform 0.3s ease;
 }
 
 .modal-content h2 {
@@ -175,6 +188,7 @@ input[type="checkbox"] {
   width: 100vw;
   height: 100vh;
   background-color: rgba(0,0,0,0.4);
+  backdrop-filter: blur(2px);
   z-index: 5;
 }
 
@@ -195,4 +209,28 @@ input[type="checkbox"] {
   box-shadow: 0 2px 6px rgba(0,0,0,0.3);
   color: white;
   text-align: center;
+  transition: transform 0.3s;
+}
+
+.cardPartido:hover {
+  transform: translateY(-5px);
+}
+
+@media (max-width: 600px) {
+  main {
+    padding: 10px;
+  }
+
+  .equipos-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .cards-container {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .cardPartido {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- add fade/scale animation for modals and cards
- blur the overlay background
- show overlay when any modal opens and close both when clicking
- make layout responsive on small screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846319d8f2c8321b74e11092f149021