### PR TITLE
Improve landing layout and load match data

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <main>
+    <div class="container">
     <div class="tabs">
       <button onclick="mostrarTab('tabCargar')">📋 Cargar Partido</button>
       <button onclick="mostrarTab('tabEstadisticas')">📈 Estadísticas</button>
@@ -84,13 +85,9 @@
       </div>
     </div>
 
-    <div id="overlay" class="overlay" onclick="cerrarModalJugador()"></div>
+    <div id="overlay" class="overlay" onclick="cerrarModalJugador(); cerrarModalFormulario()"></div>
 
-    <section>
-      <h2>Últimos partidos</h2>
-      <div id="cardsPartidos" class="cards-container"></div>
-    </section>
-
+    </div> <!-- container -->
     <script src="script.js"></script>
   </main>
 </body>

--- a/script.js
+++ b/script.js
@@ -19,16 +19,26 @@ async function cargarJugadores() {
   }
 }
 
-// 🧩 Modal de jugador
-function abrirModalJugador() {
-  document.getElementById("modalJugador").style.display = "flex";
-  document.getElementById("overlay").style.display = "block";
+// 🔄 Cargar partidos desde Google Sheets
+async function cargarPartidos() {
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/Partidos?key=${API_KEY}`;
+  try {
+    const res = await fetch(url);
+    const data = await res.json();
+    if (!data.values) return;
+    partidos = data.values.slice(1).map((row) => ({
+      fecha_partido: row[0],
+      nombre_partido: row[1],
+      equipo: row[2],
+      jugador: row[3],
+      goles: parseInt(row[4] || "0"),
+    }));
+  } catch (err) {
+    console.error("Error al cargar partidos:", err);
+  }
 }
-function cerrarModalJugador() {
-  document.getElementById("modalJugador").style.display = "none";
-  document.getElementById("overlay").style.display = "none";
-  document.getElementById("nuevoJugador").value = "";
-}
+
+
 
 // ➕ Agregar jugador al array
 document.getElementById("formJugador").addEventListener("submit", e => {
@@ -289,8 +299,9 @@ function actualizarGrafico(tipo = "puntos") {
 }
 
 // 🎯 Eventos de carga
-document.addEventListener("DOMContentLoaded", () => {
-  cargarJugadores();
+document.addEventListener("DOMContentLoaded", async () => {
+  await Promise.all([cargarJugadores(), cargarPartidos()]);
+  renderUltimosPartidos();
   actualizarGrafico("puntos");
 
   document
@@ -318,22 +329,36 @@ function mostrarTab(tabId) {
 
 // 🪟 Abrir y cerrar modal de formulario
 function abrirModalFormulario() {
-  document.getElementById("modalFormulario").style.display = "block";
+  const modal = document.getElementById("modalFormulario");
+  const overlay = document.getElementById("overlay");
+  overlay.style.display = "block";
+  modal.style.display = "flex";
+  requestAnimationFrame(() => modal.classList.add("show"));
 }
 
 function cerrarModalFormulario() {
-  document.getElementById("modalFormulario").style.display = "none";
+  const modal = document.getElementById("modalFormulario");
+  modal.classList.remove("show");
+  const overlay = document.getElementById("overlay");
+  overlay.style.display = "none";
+  setTimeout(() => (modal.style.display = "none"), 300);
   document.getElementById("formPartido").reset();
   document.querySelector(".equipos-grid").style.display = "none";
 }
 
 // 🪟 Abrir y cerrar modal de jugador nuevo
 function abrirModalJugador() {
-  document.getElementById("modalJugador").style.display = "block";
-  document.getElementById("overlay").style.display = "block";
+  const modal = document.getElementById("modalJugador");
+  const overlay = document.getElementById("overlay");
+  overlay.style.display = "block";
+  modal.style.display = "flex";
+  requestAnimationFrame(() => modal.classList.add("show"));
 }
 
 function cerrarModalJugador() {
-  document.getElementById("modalJugador").style.display = "none";
-  document.getElementById("overlay").style.display = "none";
+  const modal = document.getElementById("modalJugador");
+  modal.classList.remove("show");
+  const overlay = document.getElementById("overlay");
+  overlay.style.display = "none";
+  setTimeout(() => (modal.style.display = "none"), 300);
 }

--- a/style.css
+++ b/style.css
@@ -13,26 +13,35 @@ main {
   min-height: 100vh;
 }
 
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+
 .tabs {
   display: flex;
-  gap: 10px;
+  gap: 15px;
   margin-bottom: 20px;
   justify-content: center;
 }
 
+
 .tabs button {
-  padding: 10px 15px;
-  border: none;
-  background-color: rgba(255,255,255,0.1);
+  padding: 20px;
+  border: 1px solid rgba(255,255,255,0.2);
+  background-color: rgba(255,255,255,0.08);
   color: white;
   cursor: pointer;
-  border-radius: 5px;
-  transition: background-color 0.3s, transform 0.2s;
+  border-radius: 8px;
+  transition: background-color 0.3s, transform 0.2s, box-shadow 0.3s;
+  min-width: 130px;
 }
 
 .tabs button:hover {
-  background-color: rgba(255,255,255,0.2);
-  transform: scale(1.03);
+  background-color: rgba(255,255,255,0.15);
+  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+  transform: translateY(-3px);
 }
 
 .tab {
@@ -139,6 +148,17 @@ input[type="checkbox"] {
   justify-content: center;
   align-items: center;
   z-index: 10;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.modal.show {
+  display: flex;
+  opacity: 1;
+}
+
+.modal.show .modal-content {
+  transform: scale(1);
 }
 
 .modal-content {
@@ -150,6 +170,8 @@ input[type="checkbox"] {
   position: relative;
   color: white;
   backdrop-filter: blur(4px);
+  transform: scale(0.95);
+  transition: transform 0.3s ease;
 }
 
 .modal-content h2 {
@@ -175,14 +197,15 @@ input[type="checkbox"] {
   width: 100vw;
   height: 100vh;
   background-color: rgba(0,0,0,0.4);
+  backdrop-filter: blur(2px);
   z-index: 5;
 }
 
 .cards-container {
   display: flex;
   flex-wrap: wrap;
-  gap: 15px;
-  margin-top: 20px;
+  gap: 10px;
+  margin-top: 15px;
   justify-content: center;
 }
 
@@ -195,4 +218,34 @@ input[type="checkbox"] {
   box-shadow: 0 2px 6px rgba(0,0,0,0.3);
   color: white;
   text-align: center;
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.cardPartido:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 6px 12px rgba(0,0,0,0.4);
+}
+
+@media (max-width: 600px) {
+  main {
+    padding: 10px;
+  }
+
+  .equipos-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .tabs {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .cards-container {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .cardPartido {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- fetch matches from Google Sheets on load
- center content inside a container and add card-style tabs
- tune card spacing and hover effects for a tighter landing
- render latest matches and charts with fetched data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846319d8f2c8321b74e11092f149021