### PR TITLE
Fix data loading logic and cleanup duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Este proyecto es una web para registrar partidos, jugadores y estadísticas. A c
 1. Crea una hoja con las pestañas **Jugadores** y **Partidos**.
 2. Obtén el identificador de la hoja (`SHEET_ID`) y una clave de API válida (`API_KEY`).
 3. En `script.js` reemplaza los valores de `SHEET_ID` y `API_KEY` por los de tu proyecto.
+4. Ajusta la constante `WEBHOOK_PARTIDO_URL` con la URL de tu webhook de n8n para registrar los partidos.
 
 ## Paso a paso en n8n
 1. **Webhook**: crea un nuevo nodo *Webhook* con método `POST`. Obtén la URL y utilízala como `N8N_WEBHOOK_URL` en el servidor.

--- a/index.html
+++ b/index.html
@@ -81,22 +81,6 @@
 
     <div id="overlay" class="overlay" onclick="cerrarModalFormulario(); cerrarModalJugador();"></div>
 
-    <section>
-      <h2>Últimos partidos</h2>
-      <div id="ultimosPartidos" class="cards-container"></div>
-    </section>
-
-    <section id="estadisticas" class="seccion-estadisticas">
-      <h2>Estadísticas del Torneo</h2>
-      <label for="tipoGrafico">Ranking por:</label>
-      <select id="tipoGrafico">
-        <option value="puntos">Puntos</option>
-        <option value="goles">Goles</option>
-        <option value="partidos">Participaciones</option>
-      </select>
-      <canvas id="graficoJugadores"></canvas>
-    </section>
-
     <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -134,8 +134,8 @@ function renderUltimosPartidos() {
   });
 
   document.getElementById("ultimosPartidos").innerHTML = cards.join("");
+
 }
-let chartJugadores;
 
 function actualizarGrafico(tipo = "puntos") {
   const ctx = document.getElementById("graficoJugadores")?.getContext("2d");
@@ -277,6 +277,13 @@ function poblarFormulario() {
         select.appendChild(opt);
       });
 
+      select.addEventListener("change", () => {
+        prepararVotacion([
+          ...obtenerJugadores("Blanco"),
+          ...obtenerJugadores("Negro"),
+        ]);
+      });
+
       const inputGoles = document.createElement("input");
       inputGoles.type = "number";
       inputGoles.placeholder = "Goles";
@@ -305,6 +312,7 @@ function poblarFormulario() {
       contenedor.appendChild(fila);
     }
   });
+  prepararVotacion([]);
 }
 // 🧩 Obtener datos de jugadores del formulario
 function obtenerJugadores(equipo) {
@@ -400,66 +408,4 @@ function prepararVotacion(jugadoresPartido) {
   });
 
   select.style.display = "block";
-}
-
-// 🧩 Eventos de carga inicial
-document.addEventListener("DOMContentLoaded", () => {
-  cargarDatos().then(() => {
-    actualizarGrafico("puntos");
-    renderUltimosPartidos();
-  });
-
-  document.getElementById("tipoGrafico")?.addEventListener("change", (e) => {
-    actualizarGrafico(e.target.value);
-  });
-
-  document.getElementById("nombre_partido")?.addEventListener("change", () => {
-    if (document.getElementById("nombre_partido").value.trim()) {
-      poblarFormulario();
-      document.querySelector(".equipos-grid").style.display = "grid";
-    }
-  });
-});
-
-// 🎛 Cambiar entre pestañas
-function mostrarTab(tabId) {
-  document.querySelectorAll(".tab").forEach(tab => {
-    tab.style.display = "none";
-  });
-  document.getElementById(tabId).style.display = "block";
-}
-
-// 🪟 Abrir y cerrar modal de formulario
-function abrirModalFormulario() {
-  const modal = document.getElementById("modalFormulario");
-  const overlay = document.getElementById("overlay");
-  overlay.style.display = "block";
-  modal.style.display = "flex";
-  requestAnimationFrame(() => modal.classList.add("show"));
-}
-
-function cerrarModalFormulario() {
-  const modal = document.getElementById("modalFormulario");
-  modal.classList.remove("show");
-  const overlay = document.getElementById("overlay");
-  overlay.style.display = "none";
-  setTimeout(() => (modal.style.display = "none"), 300);
-  document.getElementById("formPartido").reset();
-  document.querySelector(".equipos-grid").style.display = "none";
-}
-// 🪟 Abrir y cerrar modal de jugador nuevo
-function abrirModalJugador() {
-  const modal = document.getElementById("modalJugador");
-  const overlay = document.getElementById("overlay");
-  overlay.style.display = "block";
-  modal.style.display = "flex";
-  requestAnimationFrame(() => modal.classList.add("show"));
-}
-
-function cerrarModalJugador() {
-  const modal = document.getElementById("modalJugador");
-  modal.classList.remove("show");
-  const overlay = document.getElementById("overlay");
-  overlay.style.display = "none";
-  setTimeout(() => (modal.style.display = "none"), 300);
 }


### PR DESCRIPTION
## Summary
- fix duplicated sections in `index.html`
- streamline `script.js` and remove repeated logic
- update player form to refresh figure options
- document webhook URL in README

## Testing
- `npm start` *(fails: Cannot find module 'express')*
- `npm install` *(fails due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68464af48bf08321b4819830d52366d2